### PR TITLE
Update usages of returnProcess

### DIFF
--- a/Data Admin/duplication_combine.php
+++ b/Data Admin/duplication_combine.php
@@ -31,10 +31,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/duplication_com
 } else {
     $page->breadcrumbs->add(__('Combine Similar Fields', 'Data Admin'));
 
-    if (isset($_GET['return'])) {
-        returnProcess($guid, $_GET['return'], null, null);
-    }
-
     echo '<p>';
     echo __("With user-entered data it's common to end up with a variety of details that all mean the same thing or are spelled incorrectly. These discrepancies can have an effect on reports generated. Use the tool below to help find and combine fields with similar data.", 'Data Admin');
     echo '</p>';
@@ -45,7 +41,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/duplication_com
 
     $form = Form::create('combineFieldsFilder', $session->get('absoluteURL').'/index.php?q=/modules/Data Admin/duplication_combine.php');
     $form->addHiddenValue('address', $session->get('address'));
-    
+
     $tableData = include __DIR__ . '/src/CombineableFields.php';
 
     // Build a set of options for the chained selects
@@ -79,20 +75,20 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/duplication_com
     $row = $form->addRow();
     $row->addLabel('mode', __('Mode'));
     $row->addRadio('mode')->fromArray(array('Assisted' => __('Assisted'), 'Manual' => __('Manual')))->checked($mode);
-    
+
     $row = $form->addRow();
     $row->addFooter();
     $row->addSubmit();
-    
+
     echo $form->getOutput();
 
     // Validate against data set to prevent unwanted values in SQL query
     if (!empty($fieldName) && array_key_exists($tableName, $tableData) && array_key_exists($fieldName, $tableData[$tableName]['fields'])) {
         if ($mode == 'Assisted') {
             $sql = "SELECT DISTINCT match1.`$fieldName` as matched, match2.`$fieldName` as value
-            FROM `$tableName` as match1, `$tableName` as match2 
-            WHERE match2.`$fieldName` LIKE CONCAT('%', match1.`$fieldName`, '%') 
-            AND LENGTH(match1.`$fieldName`) < LENGTH(match2.`$fieldName`) 
+            FROM `$tableName` as match1, `$tableName` as match2
+            WHERE match2.`$fieldName` LIKE CONCAT('%', match1.`$fieldName`, '%')
+            AND LENGTH(match1.`$fieldName`) < LENGTH(match2.`$fieldName`)
             AND LENGTH(match1.`$fieldName`) > 2
             AND (match1.`$fieldName` <> match2.`$fieldName`)
             AND match1.`$fieldName` <> ''
@@ -100,7 +96,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/duplication_com
         } else {
             $sql = "SELECT `$fieldName` as value, count(*) as count FROM `$tableName` GROUP BY value ORDER BY value";
         }
-        
+
         $result = $pdo->executeQuery(array(), $sql);
 
         echo '<h3>';
@@ -110,7 +106,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/duplication_com
         if ($result->rowCount() == 0) {
             echo Format::alert(__('There are no records to display.'), 'message');
         } else {
-            
+
 
             if ($mode == 'Assisted') {
                 echo '<p>';

--- a/Data Admin/settings.php
+++ b/Data Admin/settings.php
@@ -31,10 +31,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/settings.php") 
 } else {
     $page->breadcrumbs->add(__('Data Admin Settings', 'Data Admin'));
 
-    if (isset($_GET['return'])) {
-        returnProcess($guid, $_GET['return'], null, null);
-    }
-
     $trueIcon = "<img title='" . __('Yes'). "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png' width=16 height=16 />";
     $falseIcon = "<img title='" . __('No'). "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png' width=16 height=16 />";
 
@@ -145,7 +141,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/settings.php") 
 		</tr>
 
     </table></br>
-    
+
     <?php
 
     $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/settingsProcess.php');

--- a/Data Admin/snapshot_manage.php
+++ b/Data Admin/snapshot_manage.php
@@ -35,10 +35,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/snapshot_manage
     echo __("Manage Snapshots", 'Data Admin') ;
     echo "</h3>" ;
 
-    if (isset($_GET["return"])) {
-        returnProcess($guid, $_GET["return"], null, null);
-    }
-
     echo "<div class='warning'>" ;
     echo __('Database snapshots allow you to save and restore your entire Gibbon database, which can be useful before importing data. They should NOT be used on live systems or when other users are online. Snapshots should NOT be used in place of standard backup procedures. A snapshot only saves MySQL data and does not save uploaded files or preserve any changes to the file system.', 'Data Admin');
     echo "</div>" ;

--- a/Data Admin/snapshot_manage_add.php
+++ b/Data Admin/snapshot_manage_add.php
@@ -33,8 +33,6 @@ else {
         ->add(__('Manage Snapshots', 'Data Admin'), 'snapshot_manage.php')
         ->add(__('Create Snapshot', 'Data Admin'));
 
-	if (isset($_GET["return"])) { returnProcess($guid, $_GET["return"], null, null); }
-
 	echo "<div class='warning'>" ;
 	echo __('Database snapshots allow you to save and restore your entire Gibbon database, which can be useful before importing data. They should NOT be used on live systems or when other users are online. Snapshots should NOT be used in place of standard backup procedures. A snapshot only saves MySQL data and does not save uploaded files or preserve any changes to the file system.', 'Data Admin');
 	echo "</div>" ;
@@ -42,7 +40,7 @@ else {
 	echo "<div class='warning'>" ;
 	echo __('Database files can be quite large, do not refresh the page after pressing submit. Also, this may fail if PHP does not have access to execute system commands.', 'Data Admin');
     echo "</div>" ;
-    
+
     $form = Form::create('deleteRecord', $session->get('absoluteURL').'/modules/'.$session->get('module').'/snapshot_manage_addProcess.php');
     $form->addHiddenValue('address', $_GET['q']);
 

--- a/Data Admin/snapshot_manage_delete.php
+++ b/Data Admin/snapshot_manage_delete.php
@@ -29,14 +29,10 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/snapshot_manage
     echo __("You do not have access to this action.") ;
     echo "</div>" ;
 } else {
-    //Proceed!
-    if (isset($_GET["return"])) {
-        returnProcess($guid, $_GET["return"], null, null);
-    }
-    
+
     //Check if file exists
     $filename=(isset($_GET["file"]))? $_GET["file"] : '' ;
-    
+
     if ($filename=="") {
         echo "<div class='error'>" ;
         echo __("You have not specified one or more required parameters.") ;
@@ -54,7 +50,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/snapshot_manage
             echo "</div>" ;
         } else {
             //Let's go!
-            
+
             $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module').'/snapshot_manage_deleteProcess.php?file='.$filename);
             echo $form->getOutput();
         }

--- a/Data Admin/snapshot_manage_load.php
+++ b/Data Admin/snapshot_manage_load.php
@@ -37,14 +37,10 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/snapshot_manage
     echo __("Load Snapshot", 'Data Admin');
     echo "</h3>";
 
-    if (isset($_GET["return"])) {
-        returnProcess($guid, $_GET["return"], null, null);
-    }
-
     echo "<div class='warning'>";
     echo __('Loading a snapshot is a HIGHLY DESTRUCTIVE operation. It will overwrite all data in Gibbon. Do not proceed unless you are absolutly certain you know what you\'re doing.', 'Data Admin');
     echo "</div>";
-    
+
     //Check if file exists
     $filename = (isset($_GET["file"])) ? $_GET["file"] : '';
     if ($filename == "") {

--- a/Data Admin/tools_findUsernames.php
+++ b/Data Admin/tools_findUsernames.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/tools_findUsern
     $page->breadcrumbs->add(__('Find Usernames', 'Data Admin'));
 
     if (isset($_GET['return'])) {
-        returnProcess($guid, $_GET['return'], null, ['error4' => __('Import cannot proceed, the file type cannot be read.') ]);
+        $page->return->addReturn('error4', __('Import cannot proceed, the file type cannot be read.'));
     }
 
     echo '<p>';
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/tools_findUsern
     $row = $form->addRow()->addClass('oneColumnOptions');
     $row->addLabel('nameFormat', __('Name Format'))->description(__('What format are the names currently in?'));
     $row->addSelect('nameFormat')->fromArray($formats)->required()->placeholder();
-    
+
     $row = $form->addRow()->addClass('oneColumnOptions');
     $row->addLabel('nameColumn', __('Name Column'))->description(__('What column are the names in?'));
     $row->addSelect('nameColumn')->fromArray($columns)->required()->placeholder();
@@ -120,6 +120,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Data Admin/tools_findUsern
     $row = $form->addRow();
     $row->addFooter();
     $row->addSubmit();
-    
+
     echo $form->getOutput();
 }


### PR DESCRIPTION
* Since v22.0.00, returnProcess() no longer process the second parameter $return. All usage of returnProcess with only that parameter can be removed.

* Since v22.0.00, returnProcess() would pass $customReturns to $page->return->addReturns(). Calls of returnProcess with $customReturns can be converted to $page->return->addReturn().